### PR TITLE
add form deletion confirmation modal when deleting from form settings

### DIFF
--- a/src/app/(main)/dashboard/_components/delete-form-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/delete-form-dialog.tsx
@@ -16,9 +16,15 @@ import { api } from "~/trpc/react";
 
 type DeleteFormDialogProps = {
   formId: string;
+  showTrashIcon?: boolean;
+  onSuccessfulDelete?: () => void;
 };
 
-export function DeleteFormDialog({ formId }: DeleteFormDialogProps) {
+export function DeleteFormDialog({
+  formId,
+  showTrashIcon,
+  onSuccessfulDelete,
+}: DeleteFormDialogProps) {
   const [open, setOpen] = useState(false);
 
   const router = useRouter();
@@ -35,6 +41,7 @@ export function DeleteFormDialog({ formId }: DeleteFormDialogProps) {
           toast.success("Your form has been deleted", {
             icon: <TrashIcon className="h-4 w-4" />,
           });
+          onSuccessfulDelete?.();
         },
       },
     );
@@ -44,7 +51,9 @@ export function DeleteFormDialog({ formId }: DeleteFormDialogProps) {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <div className="group flex w-full items-center gap-2 rounded-md hover:cursor-pointer dark:bg-none">
-          <TrashIcon className="h-4 w-4 duration-300 group-hover:text-red-500 dark:text-white" />
+          {showTrashIcon && (
+            <TrashIcon className="h-4 w-4 duration-300 group-hover:text-red-500 dark:text-white" />
+          )}
           <span className="hover:text-red-500">Delete</span>
         </div>
       </DialogTrigger>

--- a/src/app/(main)/dashboard/_components/form-card.tsx
+++ b/src/app/(main)/dashboard/_components/form-card.tsx
@@ -13,7 +13,7 @@ import {
 } from "~/components/ui/dropdown-menu";
 import type { RouterOutputs } from "~/trpc/shared";
 
-import { DeleteFormDialog } from "./delete-form-dialog";
+import { DeleteFormDialog } from "../../form/delete-form-dialog";
 
 type FormCardProp = {
   form: RouterOutputs["form"]["userForms"][number];

--- a/src/app/(main)/form/[id]/form-settings.tsx
+++ b/src/app/(main)/form/[id]/form-settings.tsx
@@ -22,6 +22,7 @@ import { Switch } from "~/components/ui/switch";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/shared";
 
+import { DeleteFormDialog } from "../../dashboard/_components/delete-form-dialog";
 import { refreshDashboardAfterDeletion } from "../_actions/refresh-dashboard-after-deletion";
 
 const formNameSchema = z.object({
@@ -61,34 +62,9 @@ export function FormSettings({ form }: FormSettingsProps) {
     return null;
   }
 
-  const utils = api.useUtils();
-
-  const { mutateAsync: deleteForm, isLoading: isDeletingForm } =
-    api.form.delete.useMutation({
-      async onSuccess() {
-        utils.form.invalidate();
-
-        // router.refresh();
-        await refreshDashboardAfterDeletion();
-        router.push("/dashboard");
-
-        toast("Your form has been deleted", {
-          icon: <FolderX className="h-4 w-4" />,
-        });
-      },
-    });
-
-  const handleDeleteForm = async () => {
-    try {
-      await deleteForm({ id: form.id });
-    } catch (e) {
-      console.log(e);
-
-      toast("Failed to delete form", {
-        description: "Please try again later",
-        icon: <FolderX className="h-4 w-4" />,
-      });
-    }
+  const redirectToDashboard = async () => {
+    await refreshDashboardAfterDeletion();
+    router.push("/dashboard");
   };
 
   return (
@@ -114,15 +90,13 @@ export function FormSettings({ form }: FormSettingsProps) {
             Delete your form with all your submissions
           </p>
         </div>
-        {/* TODO: Dialog to Confirm Deleting */}
-        <Button
-          type="button"
-          loading={isDeletingForm}
-          variant="destructive"
-          onClick={handleDeleteForm}
-        >
-          Delete Form
-        </Button>
+        <div>
+          <DeleteFormDialog
+            formId={form.id}
+            showTrashIcon={false}
+            onSuccessfulDelete={redirectToDashboard}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/(main)/form/[id]/form-settings.tsx
+++ b/src/app/(main)/form/[id]/form-settings.tsx
@@ -22,8 +22,8 @@ import { Switch } from "~/components/ui/switch";
 import { api } from "~/trpc/react";
 import { type RouterOutputs } from "~/trpc/shared";
 
-import { DeleteFormDialog } from "../../dashboard/_components/delete-form-dialog";
 import { refreshDashboardAfterDeletion } from "../_actions/refresh-dashboard-after-deletion";
+import { DeleteFormDialog } from "../delete-form-dialog";
 
 const formNameSchema = z.object({
   name: z.string().min(1).optional(),

--- a/src/app/(main)/form/delete-form-dialog.tsx
+++ b/src/app/(main)/form/delete-form-dialog.tsx
@@ -28,7 +28,8 @@ export function DeleteFormDialog({
   const [open, setOpen] = useState(false);
 
   const router = useRouter();
-  const { mutateAsync: deleteForm } = api.form.delete.useMutation();
+  const { mutateAsync: deleteForm, isLoading: isFormDeleting } =
+    api.form.delete.useMutation();
 
   const handleDelete = async () => {
     await deleteForm(
@@ -50,21 +51,17 @@ export function DeleteFormDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <div className="group flex w-full items-center gap-2 rounded-md hover:cursor-pointer dark:bg-none">
-          {showTrashIcon && (
-            <TrashIcon className="h-4 w-4 duration-300 group-hover:text-red-500 dark:text-white" />
-          )}
-          <span className="hover:text-red-500">Delete</span>
-        </div>
+        <Button variant="destructive">Delete Form</Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Are you sure you want to delete this form?</DialogTitle>
+          <DialogTitle>Delete Form</DialogTitle>
           <DialogDescription>
-            This will delete all associated submissions and cannot be undone.
+            Are you sure you want to delete this form? This action cannot be
+            undone.
           </DialogDescription>
         </DialogHeader>
-        <div className="mt-3 flex w-full gap-4">
+        <div className="flex w-full gap-4">
           <Button
             variant="outline"
             className="w-full"
@@ -75,6 +72,7 @@ export function DeleteFormDialog({
           <Button
             variant="destructive"
             className="w-full"
+            loading={isFormDeleting}
             onClick={handleDelete}
           >
             Delete


### PR DESCRIPTION
initially when a user clicks on delete, the form is just deleted just like that, making it succeptible to accidental from deletes. in this PR, we add the confirmation modal component to the form settings and also extend the modal component to have an optional callback that can be called after a successful form deletion. callback method when a deletion is successful.
