### PR TITLE
feat: add spam protection via honeypot

### DIFF
--- a/src/app/(main)/form/[id]/submissions-table.tsx
+++ b/src/app/(main)/form/[id]/submissions-table.tsx
@@ -37,6 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
+import { cn } from "~/lib/utils";
 import { api } from "~/trpc/react";
 
 type SubmissionsTableProps = {
@@ -187,7 +188,13 @@ export function SubmissionsTable({
         return (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
+              <Button
+                variant="ghost"
+                className={cn(
+                  "h-8 w-8 p-0",
+                  row.original.isSpam && "hover:bg-red-100",
+                )}
+              >
                 <span className="sr-only">Open menu</span>
                 <DotsHorizontalIcon className="h-4 w-4" />
               </Button>
@@ -260,6 +267,10 @@ export function SubmissionsTable({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
+                  className={cn(
+                    row.original.isSpam &&
+                      "bg-red-100 duration-300 hover:bg-red-50",
+                  )}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -106,6 +106,7 @@ export const formDatas = createTable(
     formId: text("form_id").notNull(),
     data: json("data").notNull(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
+    isSpam: boolean("is_spam").default(false).notNull(),
   },
   (t) => ({
     formIdx: index("form_idx").on(t.formId),


### PR DESCRIPTION
when a form is filled by a bot, it contains the key `_gotcha` in the formdata, using that, we can identify that the form was submitted by a bot and then flag it as a spam submission.
