### PR TITLE
Add "Docs" link to Dashboard Navigation

### DIFF
--- a/apps/web/src/app/(main)/dashboard/_components/dashboard-nav.tsx
+++ b/apps/web/src/app/(main)/dashboard/_components/dashboard-nav.tsx
@@ -25,6 +25,11 @@ const items = [
     href: '/dashboard/settings',
     icon: GearIcon,
   },
+  {
+    title: 'Docs',
+    href: 'https://docs.formbase.dev/',
+    icon: BookOpenIcon,
+  },
 ];
 
 interface Props {


### PR DESCRIPTION
This pull request adds a "Docs" option to the dashboard navigation. The new link points to the documentation at https://docs.formbase.dev/ for improved usability.
## Changes
Added a new item to the items array in DashboardNav component with the title "Docs", href https://docs.formbase.dev/, and BookOpenIcon as the icon.
Fixes issue #86 